### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@ pub fn print_ascii_board(board: ArrayView2<u8>) {
 pub fn print_board<T>(board: ArrayView2<T>)
     where T: std::fmt::Display
 {
-    let widest_number = board.iter().map(|x| format!("{x:.}").len()).max().unwrap();
+    let widest_number = board.iter().map(|x| format!("{x}").len()).max().unwrap();
     for row in board.rows() {
         for element in row {
-            print!("{: >width$.}", element, width = (widest_number+1));
+            print!("{: >width$}", element, width = (widest_number+1));
         }
         println!()
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.